### PR TITLE
Fix Code of Conduct Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ specific language governing permissions and limitations under the License.
 
 <!-- references -->
 [cncf]: https://www.cncf.io/about
-[coc]: wiki/Linkerd-code-of-conduct
+[coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
 [docker-badge]: https://img.shields.io/docker/pulls/buoyantio/linkerd.svg
 [docker]: https://hub.docker.com/r/buoyantio/linkerd/
 [finagle]: https://twitter.github.io/finagle/


### PR DESCRIPTION
I took the liberty of directly submitting a PR for this since I assume the change is small enough 😊

The CoC link on the README was pointing to 'https://github.com/linkerd/linkerd/blob/master/wiki/Linkerd-code-of-conduct', which doesn't exist.

I changed it to an absolute URL to keep the link working on clones and forks.

Cheers,
Amédée